### PR TITLE
pkg/cryptstate: remove NULL crypto mode.

### DIFF
--- a/pkg/cryptstate/cryptstate.go
+++ b/pkg/cryptstate/cryptstate.go
@@ -58,8 +58,6 @@ func createMode(mode string) (CryptoMode, error) {
 		return &ocb2Mode{}, nil
 	case "XSalsa20-Poly1305":
 		return &secretBoxMode{}, nil
-	case "NULL":
-		return &nullMode{}, nil
 	}
 	return nil, errors.New("cryptstate: no such CryptoMode")
 }

--- a/pkg/cryptstate/cryptstate_test.go
+++ b/pkg/cryptstate/cryptstate_test.go
@@ -160,29 +160,3 @@ func TestXSalsa20Poly1305Decrypt(t *testing.T) {
 		t.Fatalf("mismatch! got\n%x\n, expected\n%x", dst, expected)
 	}
 }
-
-func TestNullEncrypt(t *testing.T) {
-	cs := CryptState{}
-	cs.SetKey("NULL", []byte{}, []byte{1}, []byte{1})
-	msg := []byte("HelloWorld")
-	dst := make([]byte, len(msg)+cs.Overhead())
-	cs.Encrypt(dst, msg)
-	if !bytes.Equal(dst[1:], msg) {
-		t.Fatalf("mismatch! got\n%x\n, expected\n%x", dst, msg)
-	}
-}
-
-func TestNullDecrypt(t *testing.T) {
-	cs := CryptState{}
-	cs.SetKey("NULL", []byte{}, []byte{1}, []byte{1})
-	msg := []byte{2}
-	msg = append(msg, []byte("HelloWorld")...)
-	dst := make([]byte, len(msg)-cs.Overhead())
-	err := cs.Decrypt(dst, msg)
-	if err != nil {
-		t.Fatalf("%v", err)
-	}
-	if !bytes.Equal(dst, msg[1:]) {
-		t.Fatalf("mismatch! got\n%x\n, expected\n%x", dst, msg)
-	}
-}


### PR DESCRIPTION
It's not too sensible to have a NULL mode in the first place,
and the CryptState code expects non-0 IVs and keys.

Drop it.