### PR TITLE
freezer_windows: make ReplaceFile call fall back to os.Rename.

### DIFF
--- a/cmd/grumble/freeze_windows.go
+++ b/cmd/grumble/freeze_windows.go
@@ -8,6 +8,7 @@ import (
 	"github.com/golang/protobuf/proto"
 	"io/ioutil"
 	"mumble.info/grumble/pkg/replacefile"
+	"os"
 	"path/filepath"
 	"strconv"
 )
@@ -50,9 +51,16 @@ func (server *Server) freezeToFile() (err error) {
 	src := f.Name()
 	dst := filepath.Join(Args.DataDir, "servers", strconv.FormatInt(server.Id, 10), "main.fz")
 	backup := filepath.Join(Args.DataDir, "servers", strconv.FormatInt(server.Id, 10), "backup.fz")
+
 	err = replacefile.ReplaceFile(dst, src, backup, replacefile.Flag(0))
-	if err != nil {
-		return err
+	// If the dst file does not exist (as in, on first launch)
+	// fall back to os.Rename. ReplaceFile does not work if the
+	// dst file is not there.
+	if os.IsNotExist(err) {
+		err = os.Rename(src, dst)
+		if err != nil {
+			return err
+		}
 	}
 
 	return nil


### PR DESCRIPTION
ReplaceFile fails because dst does not yet exist.
To remedy this, we fall back to os.Rename, which makes
everything work as it should.