### PR TITLE
Go 1.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: go
 
 go:
   - 1.9
+  - 1.10.x
 
 go_import_path: mumble.info/grumble
 

--- a/pkg/blobstore/blobstore_test.go
+++ b/pkg/blobstore/blobstore_test.go
@@ -56,7 +56,7 @@ func TestReadNonExistantKey(t *testing.T) {
 	key := hex.EncodeToString(h.Sum(nil))
 	buf, err := bs.Get(key)
 	if err != ErrNoSuchKey {
-		t.Error("Expected no such key %v, found it anyway. (buf=%v, err=%v)", key, buf, err)
+		t.Errorf("Expected no such key %v, found it anyway. (buf=%v, err=%v)", key, buf, err)
 		return
 	}
 }
@@ -77,7 +77,7 @@ func TestReadInvalidKeyLength(t *testing.T) {
 
 	_, err = bs.Get(key)
 	if err != ErrBadKey {
-		t.Error("Expected invalid key for %v, got %v", key, err)
+		t.Errorf("Expected invalid key for %v, got %v", key, err)
 		return
 	}
 }


### PR DESCRIPTION
- Fix failing `pkg/blobstore` tests under Go 1.10
- Add 1.10 to .travis.yml