### PR TITLE
Docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+FROM golang:1.9 as builder
+
+COPY . /go/src/mumble.info/grumble
+
+WORKDIR /go/src/mumble.info/grumble
+
+RUN go get -v -t ./... \
+  && go build mumble.info/grumble/cmd/grumble \
+  && go test -v ./...
+
+FROM golang:1.9
+
+COPY --from=builder /go/bin /go/bin
+
+ENV DATADIR /data
+
+RUN mkdir /data
+
+WORKDIR /data
+
+VOLUME /data
+
+ENTRYPOINT [ "/go/bin/grumble", "--datadir", "/data", "--log", "/data/grumble.log" ]

--- a/Dockerfile.arm32v6
+++ b/Dockerfile.arm32v6
@@ -1,0 +1,24 @@
+FROM arm32v6/golang:1.9-alpine as builder
+
+COPY . /go/src/mumble.info/grumble
+
+WORKDIR /go/src/mumble.info/grumble
+
+RUN apk add --no-cache git \
+  && go get -v -t ./... \
+  && go build mumble.info/grumble/cmd/grumble \
+  && go test -v ./...
+
+FROM arm32v6/golang:1.9-alpine
+
+COPY --from=builder /go/bin /go/bin
+
+ENV DATADIR /data
+
+RUN mkdir /data
+
+WORKDIR /data
+
+VOLUME /data
+
+ENTRYPOINT [ "/go/bin/grumble", "--datadir", "/data", "--log", "/data/grumble.log" ]

--- a/README.md
+++ b/README.md
@@ -68,12 +68,12 @@ Docker
 
 ## Running
 
-### Docker CLI
+### Command line
 
     $ docker run \
       -v $HOME/.grumble:/data \
-      -p 64738:64738
-      -p 64738:64738/udp
+      -p 64738:64738 \
+      -p 64738:64738/udp \
       mumble-voip/grumble
 
 ### Compose

--- a/README.md
+++ b/README.md
@@ -54,3 +54,36 @@ It is architected this way because it allowed me to write a pure-Go program with
 The current thinking is that if registered users are taking up too much of your memory, you should use an external authenticator. But that code isn't written yet. The concept would be equivalent to Murmur's authenticator API via RPC. But a Grumble authenticator would probably be set up more akin to a webhook -- so just a URL in the config file.
 
 Then there's the API problem. You can't currently remote control Grumble. Which can make it hard to use in production. I imagine Grumble will grow an API that it makes available via HTTP. Murmur's API is already quite stateless in many regards, so it shouldn't be too much of a stretch to put a RESTful API in Grumble to do the same job.
+
+Docker
+==============
+
+## Getting the image
+
+### Building
+
+    $ git clone https://github.com/mumble-voip/grumble.git
+    $ cd grumble/
+    $ docker build -t mumble-voip/grumble .
+
+## Running
+
+### Docker CLI
+
+    $ docker run \
+      -v $HOME/.grumble:/data \
+      -p 64738:64738
+      -p 64738:64738/udp
+      mumble-voip/grumble
+
+### Compose
+
+    version: '3'
+    services:
+      grumble:
+        image: mumble-voip/grumble
+        ports:
+          - 64738:64738
+          - 64738:64738/udp
+        volumes:
+          - $HOME/.grumble:/data


### PR DESCRIPTION
Hello everyone.

Wanting to run Grumble on my cluster I took the liberty of 'Dockerizing' it for amd64 and arm32v6.

Both images have been tested and currently are able to build and run Grumble with persistence.

Basic instructions also included in the README.

Any feedback is appreciated. Keep up the good work.