### PR TITLE
Reduce Docker image footprint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,17 @@
-FROM golang:1.9 as builder
+FROM golang:1.9-alpine as builder
 
 COPY . /go/src/mumble.info/grumble
 
 WORKDIR /go/src/mumble.info/grumble
 
-RUN go get -v -t ./... \
+RUN apk add --no-cache git \
+  && go get -v -t ./... \
   && go build mumble.info/grumble/cmd/grumble \
   && go test -v ./...
 
-FROM golang:1.9
+FROM alpine:edge
 
-COPY --from=builder /go/bin /go/bin
+COPY --from=builder /go/bin/grumble /usr/bin/grumble
 
 ENV DATADIR /data
 
@@ -20,4 +21,4 @@ WORKDIR /data
 
 VOLUME /data
 
-ENTRYPOINT [ "/go/bin/grumble", "--datadir", "/data", "--log", "/data/grumble.log" ]
+ENTRYPOINT [ "/usr/bin/grumble", "--datadir", "/data", "--log", "/data/grumble.log" ]

--- a/Dockerfile.arm32v6
+++ b/Dockerfile.arm32v6
@@ -9,9 +9,9 @@ RUN apk add --no-cache git \
   && go build mumble.info/grumble/cmd/grumble \
   && go test -v ./...
 
-FROM arm32v6/golang:1.9-alpine
+FROM arm32v6/alpine:edge
 
-COPY --from=builder /go/bin /go/bin
+COPY --from=builder /go/bin/grumble /usr/bin/grumble
 
 ENV DATADIR /data
 
@@ -21,4 +21,4 @@ WORKDIR /data
 
 VOLUME /data
 
-ENTRYPOINT [ "/go/bin/grumble", "--datadir", "/data", "--log", "/data/grumble.log" ]
+ENTRYPOINT [ "/usr/bin/grumble", "--datadir", "/data", "--log", "/data/grumble.log" ]


### PR DESCRIPTION
Unfortunately I was unable to realize sooner just how big the `golang` Docker images are, currently in use by both `mumble-voip/grumble` images as a base.

The changes in this pull request bring the image size down from the hundreds of MiBs to just a dozen, by replacing the base image used on the last stage of the build.

Thank you for your time.