### PR TITLE
Fix travis-ci build status image in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 
 Linux CI (Travis CI):
 
-[![Build Status](https://travis-ci.org/mumble-voip/grumble.svg?branch=master)](https://travis-ci.org/mumble-voip/grumble)
+[![Build Status](https://travis-ci.com/mumble-voip/grumble.svg?branch=master)](https://travis-ci.org/mumble-voip/grumble)
 
 Windows CI (AppVeyor):
 


### PR DESCRIPTION
Changed https://travis-ci.org/mumble-voip/grumble.svg?branch=master to https://travis-ci.com/mumble-voip/grumble.svg?branch=master.