### PR TITLE
Ensure we don't close freezelog more than once

### DIFF
--- a/cmd/grumble/freeze.go
+++ b/cmd/grumble/freeze.go
@@ -6,19 +6,20 @@ package main
 
 import (
 	"errors"
-	"github.com/golang/protobuf/proto"
 	"io"
 	"io/ioutil"
 	"log"
+	"os"
+	"path/filepath"
+	"strconv"
+	"time"
+
+	"github.com/golang/protobuf/proto"
 	"mumble.info/grumble/pkg/acl"
 	"mumble.info/grumble/pkg/ban"
 	"mumble.info/grumble/pkg/freezer"
 	"mumble.info/grumble/pkg/mumbleproto"
 	"mumble.info/grumble/pkg/serverconf"
-	"os"
-	"path/filepath"
-	"strconv"
-	"time"
 )
 
 // Freeze a server to disk and closes the log file.
@@ -48,6 +49,7 @@ func (server *Server) openFreezeLog() error {
 		if err != nil {
 			return err
 		}
+		server.freezelog = nil
 	}
 
 	logfn := filepath.Join(Args.DataDir, "servers", strconv.FormatInt(server.Id, 10), "log.fz")

--- a/cmd/grumble/freeze_unix.go
+++ b/cmd/grumble/freeze_unix.go
@@ -7,11 +7,12 @@
 package main
 
 import (
-	"github.com/golang/protobuf/proto"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
+
+	"github.com/golang/protobuf/proto"
 )
 
 func (server *Server) freezeToFile() (err error) {
@@ -21,6 +22,7 @@ func (server *Server) freezeToFile() (err error) {
 		if err != nil {
 			return err
 		}
+		server.freezelog = nil
 	}
 
 	// Make sure the whole server is synced to disk

--- a/cmd/grumble/freeze_windows.go
+++ b/cmd/grumble/freeze_windows.go
@@ -5,12 +5,13 @@
 package main
 
 import (
-	"github.com/golang/protobuf/proto"
 	"io/ioutil"
-	"mumble.info/grumble/pkg/replacefile"
 	"os"
 	"path/filepath"
 	"strconv"
+
+	"github.com/golang/protobuf/proto"
+	"mumble.info/grumble/pkg/replacefile"
 )
 
 func (server *Server) freezeToFile() (err error) {
@@ -20,6 +21,7 @@ func (server *Server) freezeToFile() (err error) {
 		if err != nil {
 			return err
 		}
+		server.freezelog = nil
 	}
 
 	// Make sure the whole server is synced to disk


### PR DESCRIPTION
When calling Server.Stop(), it will fail because the freezelog is closed twice. It's a bit hard to find the logic that makes this happen - but a fix that makes it work is to make sure to always set the freezelog to nil after closing it. This commit does that in all places that close the freezelog.

In the files touched, imports are also rearranged by the automatic gofmt rules. I can remove that if it's too noisy.