### PR TITLE
Don't close the TCP listener, only the TLS listener

### DIFF
--- a/cmd/grumble/server.go
+++ b/cmd/grumble/server.go
@@ -1532,10 +1532,6 @@ func (server *Server) Stop() (err error) {
 	if err != nil {
 		return err
 	}
-	err = server.tcpl.Close()
-	if err != nil {
-		return err
-	}
 	err = server.webwsl.Close()
 	if err != nil {
 		return err


### PR DESCRIPTION
When calling Server.Close(), it will always fail, since it tries to close the TLS listener and then the TCP listener. However, the TLS listener wraps the TCP listener, and when the TLS listener is closed, it also automatically closes the underlying TCP listener. Thus, Stop will always return an error when trying to close the TCP listener.