### PR TITLE
Set freezelog to nil after closing it

### DIFF
--- a/cmd/grumble/freeze.go
+++ b/cmd/grumble/freeze.go
@@ -48,6 +48,7 @@ func (server *Server) openFreezeLog() error {
 		if err != nil {
 			return err
 		}
+		server.freezelog = nil
 	}
 
 	logfn := filepath.Join(Args.DataDir, "servers", strconv.FormatInt(server.Id, 10), "log.fz")

--- a/cmd/grumble/freeze_unix.go
+++ b/cmd/grumble/freeze_unix.go
@@ -21,6 +21,7 @@ func (server *Server) freezeToFile() (err error) {
 		if err != nil {
 			return err
 		}
+		server.freezelog = nil
 	}
 
 	// Make sure the whole server is synced to disk

--- a/cmd/grumble/freeze_windows.go
+++ b/cmd/grumble/freeze_windows.go
@@ -20,6 +20,7 @@ func (server *Server) freezeToFile() (err error) {
 		if err != nil {
 			return err
 		}
+		server.freezelog = nil
 	}
 
 	// Make sure the whole server is synced to disk


### PR DESCRIPTION
When calling Server.Stop(), it will fail because the freezelog is closed twice. It's a bit hard to find the logic that makes this happen - but a fix that makes it work is to make sure to always set the freezelog to nil after closing it. This commit does that in all places that close the freezelog.