### PR TITLE
Make it possible to change configuration parameters on a server

### DIFF
--- a/cmd/grumble/server.go
+++ b/cmd/grumble/server.go
@@ -1562,3 +1562,8 @@ func (server *Server) Stop() (err error) {
 
 	return nil
 }
+
+// Set will set a configuration value
+func (server *Server) Set(key string, value string) {
+	server.cfg.Set(key, value)
+}


### PR DESCRIPTION
When using Grumble as a library, it's very useful to be able to set configuration settings on the server. This PR exposes a method to make this possible.