### PR TITLE
Only send configuration updates if the channel exists

### DIFF
--- a/cmd/grumble/server.go
+++ b/cmd/grumble/server.go
@@ -193,7 +193,10 @@ func (server *Server) SetSuperUserPassword(password string) {
 	key := "SuperUserPassword"
 	val := "sha1$" + salt + "$" + digest
 	server.cfg.Set(key, val)
-	server.cfgUpdate <- &KeyValuePair{Key: key, Value: val}
+
+	if server.cfgUpdate != nil {
+		server.cfgUpdate <- &KeyValuePair{Key: key, Value: val}
+	}
 }
 
 // CheckSuperUserPassword checks whether password matches the set SuperUser password.


### PR DESCRIPTION
If you try to set the super password before the Server has been started, the program will crash because it's trying to send the update to a nil channel. This PR simply checks that the channel exists before sending on it.