### PR TITLE
Refactor logtarget

### DIFF
--- a/cmd/grumble/grumble.go
+++ b/cmd/grumble/grumble.go
@@ -37,7 +37,7 @@ func main() {
 	dataDir.Close()
 
 	// Set up logging
-	logtarget.Default, err = logtarget.OpenFile(Args.LogPath)
+	logtarget.Default, err = logtarget.OpenFile(Args.LogPath, os.Stderr)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Unable to open log file (%v): %v", Args.LogPath, err)
 		return

--- a/cmd/grumble/grumble.go
+++ b/cmd/grumble/grumble.go
@@ -44,7 +44,7 @@ func main() {
 	}
 	log.SetPrefix("[G] ")
 	log.SetFlags(log.LstdFlags | log.Lmicroseconds)
-	log.SetOutput(&logtarget.Target)
+	log.SetOutput(logtarget.Target)
 	log.Printf("Grumble")
 	log.Printf("Using data directory: %s", Args.DataDir)
 

--- a/cmd/grumble/grumble.go
+++ b/cmd/grumble/grumble.go
@@ -37,7 +37,7 @@ func main() {
 	dataDir.Close()
 
 	// Set up logging
-	err = logtarget.Default.OpenFile(Args.LogPath)
+	logtarget.Default, err = logtarget.OpenFile(Args.LogPath)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Unable to open log file (%v): %v", Args.LogPath, err)
 		return

--- a/cmd/grumble/grumble.go
+++ b/cmd/grumble/grumble.go
@@ -37,14 +37,14 @@ func main() {
 	dataDir.Close()
 
 	// Set up logging
-	err = logtarget.Target.OpenFile(Args.LogPath)
+	err = logtarget.Default.OpenFile(Args.LogPath)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Unable to open log file (%v): %v", Args.LogPath, err)
 		return
 	}
 	log.SetPrefix("[G] ")
 	log.SetFlags(log.LstdFlags | log.Lmicroseconds)
-	log.SetOutput(logtarget.Target)
+	log.SetOutput(logtarget.Default)
 	log.Printf("Grumble")
 	log.Printf("Using data directory: %s", Args.DataDir)
 

--- a/cmd/grumble/server.go
+++ b/cmd/grumble/server.go
@@ -156,7 +156,7 @@ func NewServer(id int64) (s *Server, err error) {
 	s.Channels[0] = NewChannel(0, "Root")
 	s.nextChanId = 1
 
-	s.Logger = log.New(logtarget.Target, fmt.Sprintf("[%v] ", s.Id), log.LstdFlags|log.Lmicroseconds)
+	s.Logger = log.New(logtarget.Default, fmt.Sprintf("[%v] ", s.Id), log.LstdFlags|log.Lmicroseconds)
 
 	return
 }

--- a/cmd/grumble/server.go
+++ b/cmd/grumble/server.go
@@ -156,7 +156,7 @@ func NewServer(id int64) (s *Server, err error) {
 	s.Channels[0] = NewChannel(0, "Root")
 	s.nextChanId = 1
 
-	s.Logger = log.New(&logtarget.Target, fmt.Sprintf("[%v] ", s.Id), log.LstdFlags|log.Lmicroseconds)
+	s.Logger = log.New(logtarget.Target, fmt.Sprintf("[%v] ", s.Id), log.LstdFlags|log.Lmicroseconds)
 
 	return
 }

--- a/cmd/grumble/signal_unix.go
+++ b/cmd/grumble/signal_unix.go
@@ -20,7 +20,7 @@ func SignalHandler() {
 	signal.Notify(sigchan, syscall.SIGUSR2, syscall.SIGTERM, syscall.SIGINT)
 	for sig := range sigchan {
 		if sig == syscall.SIGUSR2 {
-			err := logtarget.Target.Rotate()
+			err := logtarget.Default.Rotate()
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "unable to rotate log file: %v", err)
 			}

--- a/pkg/logtarget/logtarget.go
+++ b/pkg/logtarget/logtarget.go
@@ -6,7 +6,6 @@
 package logtarget
 
 import (
-	"bytes"
 	"io"
 	"os"
 	"sync"
@@ -23,10 +22,9 @@ type LogTarget interface {
 }
 
 type fileLogTarget struct {
-	mu     sync.Mutex
-	logfn  string
-	file   *os.File
-	memLog *bytes.Buffer
+	mu    sync.Mutex
+	logfn string
+	file  *os.File
 }
 
 var Default LogTarget

--- a/pkg/logtarget/logtarget.go
+++ b/pkg/logtarget/logtarget.go
@@ -21,56 +21,65 @@ type LogTarget interface {
 	Rotate() error
 }
 
-type fileLogTarget struct {
+// logTarget is the default implementation of a log
+// target. It can write to more than one writer at the same time
+// but only rotate one file
+type logTarget struct {
 	mu    sync.Mutex
 	logfn string
 	file  *os.File
+	w     io.Writer
+	ws    []io.Writer
 }
 
+// Default is the default log target for the application
+// It has to be initialized before used
 var Default LogTarget
+
+// OpenWriters returns a log target that will
+// log to all the given writers at the same time
+func OpenWriters(ws ...io.Writer) LogTarget {
+	target := &logTarget{}
+	target.w = io.MultiWriter(ws...)
+	return target
+}
 
 // OpenFile creates a LogTarget pointing to a log file
 // and returns it.
 // This method will open the file in append-only mode.
-func OpenFile(fileName string) (t LogTarget, err error) {
-	target := &fileLogTarget{}
+// It also takes a variable number of writers that are
+// other log targets
+func OpenFile(fileName string, ws ...io.Writer) (t LogTarget, err error) {
+	target := &logTarget{}
 	target.logfn = fileName
 	target.file, err = os.OpenFile(fileName, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0650)
 	if err != nil {
 		return nil, err
 	}
+	target.ws = ws
+	target.w = io.MultiWriter(append(ws, target.file)...)
 	return target, nil
 }
 
 // Write writes a log message to all registered io.Writers
-func (target *fileLogTarget) Write(in []byte) (int, error) {
+func (target *logTarget) Write(out []byte) (int, error) {
+	target.mu.Lock()
+	defer target.mu.Unlock()
+
+	return target.Write(out)
+}
+
+// Rotate rotates the current log file, if one is opened.
+// This method holds a lock while rotating the log file,
+// and all log writes will be held back until the rotation
+// is complete.
+func (target *logTarget) Rotate() error {
 	target.mu.Lock()
 	defer target.mu.Unlock()
 
 	if target.file == nil {
-		panic("no log file opened")
+		return nil
 	}
-
-	n, err := os.Stderr.Write(in)
-	if err != nil {
-		return n, err
-	}
-
-	n, err = target.file.Write(in)
-	if err != nil {
-		return n, err
-	}
-
-	return len(in), nil
-}
-
-// Rotate rotates the current log file.
-// This method holds a lock while rotating the log file,
-// and all log writes will be held back until the rotation
-// is complete.
-func (target *fileLogTarget) Rotate() error {
-	target.mu.Lock()
-	defer target.mu.Unlock()
 
 	// Close the existing log file
 	err := target.file.Close()
@@ -82,6 +91,7 @@ func (target *fileLogTarget) Rotate() error {
 	if err != nil {
 		return err
 	}
+	target.w = io.MultiWriter(append(target.ws, target.file)...)
 
 	return nil
 }


### PR DESCRIPTION
This PR refactors the logtarget package a bit, in order to make it more generic and useful in more situations, by making these changes:

- LogTarget is now an interface
- Changing the name of the default global variable to not "stutter" (`logtarget.Target` stutters)
- Use `io.MultiWriter` to simplify the implementation
- Allow the use of more than one writer as log outputs
- Avoid hardcoding `os.StdErr` as the second output in the logtarget package - instead specify this in the server main function
