### PR TITLE
Add support for server passwords

### DIFF
--- a/cmd/grumble/server.go
+++ b/cmd/grumble/server.go
@@ -256,6 +256,10 @@ func (server *Server) CheckServerPassword(password string) bool {
 	return server.checkConfigPassword("ServerPassword", password)
 }
 
+func (server *Server) hasServerPassword() bool {
+	return server.cfg.StringValue("ServerPassword") != ""
+}
+
 // Called by the server to initiate a new client connection.
 func (server *Server) handleIncomingClient(conn net.Conn) (err error) {
 	client := new(Client)
@@ -532,6 +536,13 @@ func (server *Server) handleAuthenticate(client *Client, msg *Message) {
 			if exists {
 				client.user = user
 			}
+		}
+	}
+
+	if client.user == nil && server.hasServerPassword() {
+		if auth.Password == nil || !server.CheckServerPassword(*auth.Password) {
+			client.RejectAuth(mumbleproto.Reject_WrongServerPW, "Invalid server password")
+			return
 		}
 	}
 

--- a/cmd/grumble/server.go
+++ b/cmd/grumble/server.go
@@ -197,9 +197,14 @@ func (server *Server) setConfigPassword(key, password string) {
 	}
 }
 
-// Set password as the new SuperUser password
+// SetSuperUserPassword sets password as the new SuperUser password
 func (server *Server) SetSuperUserPassword(password string) {
 	server.setConfigPassword("SuperUserPassword", password)
+}
+
+// SetServerPassword sets password as the new Server password
+func (server *Server) SetServerPassword(password string) {
+	server.setConfigPassword("ServerPassword", password)
 }
 
 func (server *Server) checkConfigPassword(key, password string) bool {
@@ -244,6 +249,11 @@ func (server *Server) checkConfigPassword(key, password string) bool {
 // CheckSuperUserPassword checks whether password matches the set SuperUser password.
 func (server *Server) CheckSuperUserPassword(password string) bool {
 	return server.checkConfigPassword("SuperUserPassword", password)
+}
+
+// CheckServerPassword checks whether password matches the set Server password.
+func (server *Server) CheckServerPassword(password string) bool {
+	return server.checkConfigPassword("ServerPassword", password)
 }
 
 // Called by the server to initiate a new client connection.


### PR DESCRIPTION
This PR adds support for setting a server password - this allows any person to connect, as long as they know the server password. This implementation is based on the same parts in the Murmur source code.