### PR TITLE
Refactor command line arguments handling

### DIFF
--- a/cmd/grumble/args.go
+++ b/cmd/grumble/args.go
@@ -85,16 +85,20 @@ func Usage() {
 	}
 }
 
-var Args args
+func readCommandlineArguments() args {
+	var a args
 
-func init() {
 	flag.Usage = Usage
 
-	flag.BoolVar(&Args.ShowHelp, "help", false, "")
-	flag.StringVar(&Args.DataDir, "datadir", defaultDataDir(), "")
-	flag.StringVar(&Args.LogPath, "log", defaultLogPath(), "")
-	flag.BoolVar(&Args.RegenKeys, "regen-keys", false, "")
+	flag.BoolVar(&a.ShowHelp, "help", false, "")
+	flag.StringVar(&a.DataDir, "datadir", defaultDataDir(), "")
+	flag.StringVar(&a.LogPath, "log", defaultLogPath(), "")
+	flag.BoolVar(&a.RegenKeys, "regen-keys", false, "")
 
-	flag.StringVar(&Args.SQLiteDB, "import-murmurdb", "", "")
-	flag.BoolVar(&Args.CleanUp, "cleanup", false, "")
+	flag.StringVar(&a.SQLiteDB, "import-murmurdb", "", "")
+	flag.BoolVar(&a.CleanUp, "cleanup", false, "")
+
+	flag.Parse()
+
+	return a
 }

--- a/cmd/grumble/freeze.go
+++ b/cmd/grumble/freeze.go
@@ -52,7 +52,7 @@ func (server *Server) openFreezeLog() error {
 		server.freezelog = nil
 	}
 
-	logfn := filepath.Join(Args.DataDir, "servers", strconv.FormatInt(server.Id, 10), "log.fz")
+	logfn := filepath.Join(server.DataDir, "servers", strconv.FormatInt(server.Id, 10), "log.fz")
 	err := os.Remove(logfn)
 	if os.IsNotExist(err) {
 		// fallthrough
@@ -374,13 +374,13 @@ func FreezeGroup(group acl.Group) (*freezer.Group, error) {
 // Once both the full server and the log file has been merged together
 // in memory, a new full seralized server will be written and synced to
 // disk, and the existing log file will be removed.
-func NewServerFromFrozen(name string) (s *Server, err error) {
+func NewServerFromFrozen(name string, dataDir string) (s *Server, err error) {
 	id, err := strconv.ParseInt(name, 10, 64)
 	if err != nil {
 		return nil, err
 	}
 
-	path := filepath.Join(Args.DataDir, "servers", name)
+	path := filepath.Join(dataDir, "servers", name)
 	mainFile := filepath.Join(path, "main.fz")
 	backupFile := filepath.Join(path, "backup.fz")
 	logFn := filepath.Join(path, "log.fz")
@@ -424,6 +424,7 @@ func NewServerFromFrozen(name string) (s *Server, err error) {
 	if err != nil {
 		return nil, err
 	}
+	s.DataDir = dataDir
 	s.cfg = serverconf.New(cfgMap)
 
 	// Unfreeze the server's frozen bans.

--- a/cmd/grumble/freeze_unix.go
+++ b/cmd/grumble/freeze_unix.go
@@ -30,7 +30,7 @@ func (server *Server) freezeToFile() (err error) {
 	if err != nil {
 		return err
 	}
-	f, err := ioutil.TempFile(filepath.Join(Args.DataDir, "servers", strconv.FormatInt(server.Id, 10)), ".main.fz_")
+	f, err := ioutil.TempFile(filepath.Join(server.DataDir, "servers", strconv.FormatInt(server.Id, 10)), ".main.fz_")
 	if err != nil {
 		return err
 	}
@@ -50,7 +50,7 @@ func (server *Server) freezeToFile() (err error) {
 	if err != nil {
 		return err
 	}
-	err = os.Rename(f.Name(), filepath.Join(Args.DataDir, "servers", strconv.FormatInt(server.Id, 10), "main.fz"))
+	err = os.Rename(f.Name(), filepath.Join(server.DataDir, "servers", strconv.FormatInt(server.Id, 10), "main.fz"))
 	if err != nil {
 		return err
 	}

--- a/cmd/grumble/freeze_windows.go
+++ b/cmd/grumble/freeze_windows.go
@@ -29,7 +29,7 @@ func (server *Server) freezeToFile() (err error) {
 	if err != nil {
 		return err
 	}
-	f, err := ioutil.TempFile(filepath.Join(Args.DataDir, "servers", strconv.FormatInt(server.Id, 10)), ".main.fz_")
+	f, err := ioutil.TempFile(filepath.Join(server.DataDir, "servers", strconv.FormatInt(server.Id, 10)), ".main.fz_")
 	if err != nil {
 		return err
 	}
@@ -51,8 +51,8 @@ func (server *Server) freezeToFile() (err error) {
 	}
 
 	src := f.Name()
-	dst := filepath.Join(Args.DataDir, "servers", strconv.FormatInt(server.Id, 10), "main.fz")
-	backup := filepath.Join(Args.DataDir, "servers", strconv.FormatInt(server.Id, 10), "backup.fz")
+	dst := filepath.Join(server.DataDir, "servers", strconv.FormatInt(server.Id, 10), "main.fz")
+	backup := filepath.Join(server.DataDir, "servers", strconv.FormatInt(server.Id, 10), "backup.fz")
 
 	err = replacefile.ReplaceFile(dst, src, backup, replacefile.Flag(0))
 	// If the dst file does not exist (as in, on first launch)

--- a/cmd/grumble/gencert.go
+++ b/cmd/grumble/gencert.go
@@ -20,7 +20,7 @@ import (
 // Generate a 4096-bit RSA keypair and a Grumble auto-generated X509
 // certificate. Output PEM-encoded DER representations of the resulting
 // certificate and private key to certpath and keypath.
-func GenerateSelfSignedCert(certpath, keypath string) (err error) {
+func GenerateSelfSignedCert(certpath, keypath string, dataDir string) (err error) {
 	now := time.Now()
 	tmpl := &x509.Certificate{
 		SerialNumber: big.NewInt(0),
@@ -56,7 +56,7 @@ func GenerateSelfSignedCert(certpath, keypath string) (err error) {
 		Bytes: keybuf,
 	}
 
-	certfn := filepath.Join(Args.DataDir, "cert.pem")
+	certfn := filepath.Join(dataDir, "cert.pem")
 	file, err := os.OpenFile(certfn, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0700)
 	if err != nil {
 		return err
@@ -67,7 +67,7 @@ func GenerateSelfSignedCert(certpath, keypath string) (err error) {
 		return err
 	}
 
-	keyfn := filepath.Join(Args.DataDir, "key.pem")
+	keyfn := filepath.Join(dataDir, "key.pem")
 	file, err = os.OpenFile(keyfn, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0700)
 	if err != nil {
 		return err

--- a/cmd/grumble/murmurdb.go
+++ b/cmd/grumble/murmurdb.go
@@ -39,7 +39,7 @@ const (
 const SQLiteSupport = true
 
 // Import the structure of an existing Murmur SQLite database.
-func MurmurImport(filename string) (err error) {
+func MurmurImport(filename string, dataDir string) (err error) {
 	db, err := sql.Open("sqlite", filename)
 	if err != nil {
 		panic(err.Error())
@@ -68,7 +68,7 @@ func MurmurImport(filename string) (err error) {
 			return err
 		}
 
-		err = os.Mkdir(filepath.Join(Args.DataDir, strconv.FormatInt(sid, 10)), 0750)
+		err = os.Mkdir(filepath.Join(dataDir, strconv.FormatInt(sid, 10)), 0750)
 		if err != nil {
 			return err
 		}

--- a/cmd/grumble/server.go
+++ b/cmd/grumble/server.go
@@ -122,6 +122,9 @@ type Server struct {
 
 	// Logging
 	*log.Logger
+
+	// Other configuration
+	DataDir string
 }
 
 type clientLogForwarder struct {
@@ -1425,8 +1428,8 @@ func (server *Server) Start() (err error) {
 	*/
 
 	// Wrap a TLS listener around the TCP connection
-	certFn := filepath.Join(Args.DataDir, "cert.pem")
-	keyFn := filepath.Join(Args.DataDir, "key.pem")
+	certFn := filepath.Join(server.DataDir, "cert.pem")
+	keyFn := filepath.Join(server.DataDir, "key.pem")
 	cert, err := tls.LoadX509KeyPair(certFn, keyFn)
 	if err != nil {
 		return err


### PR DESCRIPTION
This PR removes the global Args variable and instead refactors everything so that the right places have access to the datadir without a global variable. It also removes the global definition of flags, so that it's possible to use the code as a library without getting the flags defined.