### PR TITLE
Updated Dockerfile.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,12 @@
-FROM golang:1.9-alpine as builder
+FROM golang:1.14-alpine as builder
 
 COPY . /go/src/mumble.info/grumble
 
 WORKDIR /go/src/mumble.info/grumble
 
-RUN apk add --no-cache git \
-  && go get -v -t ./... \
+RUN apk add --no-cache git build-base
+
+RUN go get -v -t ./... \
   && go build mumble.info/grumble/cmd/grumble \
   && go test -v ./...
 
@@ -20,5 +21,8 @@ RUN mkdir /data
 WORKDIR /data
 
 VOLUME /data
+
+EXPOSE 64738/tcp
+EXPOSE 64738/udp
 
 ENTRYPOINT [ "/usr/bin/grumble", "--datadir", "/data", "--log", "/data/grumble.log" ]

--- a/Dockerfile.arm32v6
+++ b/Dockerfile.arm32v6
@@ -1,11 +1,12 @@
-FROM arm32v6/golang:1.9-alpine as builder
+FROM arm32v6/golang:1.14-alpine as builder
 
 COPY . /go/src/mumble.info/grumble
 
 WORKDIR /go/src/mumble.info/grumble
 
-RUN apk add --no-cache git \
-  && go get -v -t ./... \
+RUN apk add --no-cache git build-base
+
+RUN go get -v -t ./... \
   && go build mumble.info/grumble/cmd/grumble \
   && go test -v ./...
 
@@ -20,5 +21,8 @@ RUN mkdir /data
 WORKDIR /data
 
 VOLUME /data
+
+EXPOSE 64738/tcp
+EXPOSE 64738/udp
 
 ENTRYPOINT [ "/usr/bin/grumble", "--datadir", "/data", "--log", "/data/grumble.log" ]


### PR DESCRIPTION
Dockerfile now uses go 1.14, pulls in the required build packages to
build the required modules, and exposes the server ports for use.