### PR TITLE
Fix infinite loop in log writer.

### DIFF
--- a/pkg/logtarget/logtarget.go
+++ b/pkg/logtarget/logtarget.go
@@ -66,7 +66,7 @@ func (target *logTarget) Write(out []byte) (int, error) {
 	target.mu.Lock()
 	defer target.mu.Unlock()
 
-	return target.Write(out)
+	return target.w.Write(out)
 }
 
 // Rotate rotates the current log file, if one is opened.


### PR DESCRIPTION
The log writter would end up calling itself non-stop. This instead tells
the logtarget.Write function to call the MultiWriter's Write instead of
itself.