### PR TITLE
Tell servers to Stop when shutting down.

### DIFF
--- a/cmd/grumble/signal_unix.go
+++ b/cmd/grumble/signal_unix.go
@@ -8,6 +8,7 @@ package main
 
 import (
 	"fmt"
+	"log"
 	"os"
 	"os/signal"
 	"syscall"
@@ -27,6 +28,14 @@ func SignalHandler() {
 			continue
 		}
 		if sig == syscall.SIGINT || sig == syscall.SIGTERM {
+			for _, server := range servers {
+				log.Printf("Stopping server %v", server.Id)
+				err := server.Stop()
+				if err != nil {
+					log.Printf("Server err %v", err)
+				}
+			}
+			log.Print("All servers stopped. Exiting.")
 			os.Exit(0)
 		}
 	}


### PR DESCRIPTION
Run Stop() on all the server when a SIGINT or SIGTERM is received. This
should ensure any open sockets and files are closed.